### PR TITLE
tweaks to add support for native vertical tabs

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -539,7 +539,7 @@ findbar:not([hidden]) {
 /*! === tabs === */
 
 /*? tab on titlebar that's not pinned */
-.tabbrowser-tab[fadein]:not([pinned]) {
+.tabbrowser-tab[fadein][orient="horizontal"]:not([pinned]) {
   /*? min tab width */
   min-width: var(--shimmer-tab-min-width) !important;
   /*? max tab width */
@@ -556,7 +556,7 @@ findbar:not([hidden]) {
 }
 
 /*? show tab close buttons when hovering tab */
-.tabbrowser-tab:not([pinned]):hover .tab-close-button {
+.tabbrowser-tab[orient="horizontal"]:not([pinned]):hover .tab-close-button {
   display: block !important;
 }
 
@@ -576,8 +576,14 @@ spacer[part="overflow-end-indicator"], spacer[part="overflow-start-indicator"] {
 }
 
 /*? tab height and x button pos */
+#tabbrowser-tabs[orient="vertical"] .tab-background {min-height: 28px !important;}
+
+#tabbrowser-tabs[orient="vertical"][expanded] {
+	min-width: 400px !important;
+}
+
 @media not (-moz-bool-pref: "shimmer.taller-tabs") {
-  #tabbrowser-tabs, .tabbrowser-tab {
+  #tabbrowser-tabs[orient="horizontal"], .tabbrowser-tab[orient="horizontal"] {
     min-height: 38px !important;
     height: 38px !important;
   }
@@ -587,7 +593,7 @@ spacer[part="overflow-end-indicator"], spacer[part="overflow-start-indicator"] {
   }
 }
 @media (-moz-bool-pref: "shimmer.taller-tabs") {
-  #tabbrowser-tabs, .tabbrowser-tab {
+  #tabbrowser-tabs[orient="horizontal"], .tabbrowser-tab[orient="horizontal"] {
     min-height: 45px !important;
     height: 45px !important;
   }


### PR DESCRIPTION
I know this UserChrome was created with Sidebery in mind, but I've recently been using the upcoming native vertical tabs (in Nightly) and they’re quite good, so at least for me it's time to say goodbye to Sidebery. Unfortunately, some of the shimmer tweaks make the native tabs unusable, so I made a few adjustments.

Changes:

- I modified all shimmer code that affect the tabs to work horizontal-only.
- The on-hover close button is impractical when the tabs are vertical and collapsed, so I removed it; however, it remains accessible when the tabs are expanded.
- I increased the width of the vertical tabs for more comfortable reading of the titles.

This won't affect those still using Sidebery or Firefox stable, but it'll be future-proof, which is always welcome.