### PR TITLE
Adding MacOS only section to revert control buttons to default position

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -899,6 +899,25 @@ treecol {
   } */
 }
 
+/* Added MacOS specific settings to revert changes to titlebar to default position */
+@supports (-moz-osx-font-smoothing: grayscale) {
+  .titlebar-buttonbox-container {
+    position: fixed !important;
+    left: 0 !important;
+    padding: 4px !important;
+    direction: ltr !important;
+    z-index: 3 !important;
+  }
+
+  .titlebar-buttonbox {
+    margin-left: 8px !important;
+    height: 28px !important;
+  }
+
+  #navigator-toolbox {
+    padding-left: 70px !important;
+  }
+}
 
 /* review:  todo, change, fix */
 /*TODO some of the usual buttons that appear on the right-click context menu are hidden. right now you can change them at the top of `userChrome.css`. i will maybe later introduce `about:config` variables for easier customization */


### PR DESCRIPTION
This is a simple solution to #3, and adds a MacOS specific section using the following:

```css
@supports (-moz-osx-font-smoothing: grayscale) {
  ...
```

I could be wrong since I only did a bit of research but from inspecting the element using the Browser Toolbox, it seems like the three control buttons (Red Close, Yellow Minimize, and Green Maximize) are not something that Firefox has access to and can control the behaviour and style of. 

This seems to be because MacOS is defining these buttons as part of its' Window Management System, rather than something Application based like Windows. Thus, I feel like the best we can do is the put it back where most users expect them, to the top left. I've taken the liberty of making it a bit "spaced", but feel free to edit it to suit what you think fits best for this theme, since you are the author after all!

![image](https://github.com/user-attachments/assets/d724f4f3-e94a-46f6-945d-fd8e1efe93ef)

This is what it looks like now!